### PR TITLE
Fix horizontal velocity calculation in PlayerController

### DIFF
--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -98,7 +98,7 @@ public class PlayerController : MonoBehaviour, IDamageable, IAttack, IDeath, IAt
 
         rigidBody.velocity = move;
 
-        float horizontalVelocity = Vector2.Dot(rigidBody.velocity, Vector2.right);
+        float horizontalVelocity = Math.Abs(Vector2.Dot(rigidBody.velocity, Vector2.right));
         playerView.SetMovementAnimation(horizontalVelocity);
     }
 


### PR DESCRIPTION
Updated the horizontal velocity calculation to use the absolute value, ensuring it remains non-negative. This change prevents negative movement values from affecting the player's animation state.