### PR TITLE
Update scene loading in UIManager to use name

### DIFF
--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -71,6 +71,6 @@ public class UIManager : MonoBehaviour
 
     private void ToMainMenu()
     {
-        SceneManager.LoadScene(0);
+        SceneManager.LoadScene("MainMenu");
     }
 }


### PR DESCRIPTION
Modified the `ToMainMenu` method to load the "MainMenu" scene by name instead of using the scene index (0). This change enhances code readability and maintainability.