### PR TITLE
Disable player unregistration and re-enable cursor lock

### DIFF
--- a/Assets/Scripts/Multiplayer/PlayerClient.cs
+++ b/Assets/Scripts/Multiplayer/PlayerClient.cs
@@ -65,9 +65,6 @@ namespace Multiplayer.PlayerSystem
         
         protected override void UnregisterEvents()
         {
-            //PlayerConnectionManager.AllClients.Remove(this);
-            //PlayerConnectionManager.PlayerSteamIds.Remove(PlayerInfo.Value.SteamID);
-
             OnStartClient?.Invoke(null);
             PlayerInfo.OnChange -= OnPlayerDataChange;
             IsReady.OnChange -= OnIsReadyChange;
@@ -79,7 +76,7 @@ namespace Multiplayer.PlayerSystem
             
             if(!IsOwner) return;
 
-            //Cursor.lockState = CursorLockMode.Locked;
+            Cursor.lockState = CursorLockMode.Locked;
             
             foreach (var component in componentsToEnable)
             {


### PR DESCRIPTION
Commented out the player unregistration logic in the `UnregisterEvents` method of `PlayerClient.cs`, keeping the event unsubscriptions intact. Uncommented the cursor lock functionality in the `Rpc_ToggleController` method to ensure the cursor locks to the game window for the owner.