### PR TITLE
Add new components and network functionality

### DIFF
--- a/Assets/DefaultPrefabObjects.asset
+++ b/Assets/DefaultPrefabObjects.asset
@@ -19,6 +19,7 @@ MonoBehaviour:
   - {fileID: 2633904174068480997, guid: da2b42c3af959524fa884be1da3cc086, type: 3}
   - {fileID: -7029748841939316381, guid: 2279705f35fa31645a8e2a9fd7b1f1dc, type: 3}
   - {fileID: 6109553062680754445, guid: 00edc98f68e6add4e91255f6f9e72d1d, type: 3}
+  - {fileID: 8412306589285422451, guid: 0de53df5b8d4ad54b950eb2130c08bb3, type: 3}
   - {fileID: 2805681668901245417, guid: 1bd839d792dc5df42bdaae65fadfda4a, type: 3}
   - {fileID: 3875465447857652874, guid: 877cf8a0c7d1f624281dbd093469f8ea, type: 3}
   - {fileID: 8475222101369129519, guid: 8cf33e8e99a9b0c4c8f29ff725650de6, type: 3}
@@ -33,3 +34,4 @@ MonoBehaviour:
   - {fileID: 201277550, guid: 5b712878ecece354ba4ffb026c0a221c, type: 3}
   - {fileID: 201277550, guid: 26a567abbe21227428f5c3d309d1d73c, type: 3}
   - {fileID: 8192566354860284824, guid: 6331b3542e64a564c81bc39cedf70c8d, type: 3}
+  - {fileID: -1849635370616442003, guid: ad41b46d90d46a84db8d7e734165c44d, type: 3}

--- a/Assets/Prefabs/Bones.prefab
+++ b/Assets/Prefabs/Bones.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 3203510706488092942}
   - component: {fileID: 6209352966512977828}
   - component: {fileID: 6572503753976664422}
+  - component: {fileID: -1849635370616442003}
   m_Layer: 0
   m_Name: Bones
   m_TagString: Untagged
@@ -96,6 +97,58 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   item: {fileID: 11400000, guid: 4f7e67c42a17110438dcd31d90bf296a, type: 2}
+--- !u!114 &-1849635370616442003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4351147015997587858}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26b716c41e9b56b4baafaf13a523ba2e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <IsNested>k__BackingField: 0
+  WasActiveDuringEdit: 0
+  WasActiveDuringEdit_Set1: 1
+  <ComponentIndex>k__BackingField: 0
+  <PredictedSpawn>k__BackingField: {fileID: 0}
+  <PredictedOwner>k__BackingField: {fileID: 0}
+  NetworkBehaviours: []
+  InitializedParentNetworkBehaviour: {fileID: 0}
+  InitializedNestedNetworkObjects: []
+  RuntimeParentNetworkBehaviour: {fileID: 0}
+  RuntimeChildNetworkBehaviours: []
+  _isNetworked: 1
+  _isSpawnable: 1
+  _isGlobal: 0
+  _initializeOrder: 0
+  _preventDespawnOnDisconnect: 0
+  _defaultDespawnType: 0
+  NetworkObserver: {fileID: 0}
+  _enablePrediction: 0
+  _predictionType: 0
+  _graphicalObject: {fileID: 0}
+  _detachGraphicalObject: 0
+  _enableStateForwarding: 1
+  _networkTransform: {fileID: 0}
+  _ownerInterpolation: 1
+  _ownerSmoothedProperties: 255
+  _adaptiveInterpolation: 3
+  _spectatorSmoothedProperties: 255
+  _spectatorInterpolation: 2
+  _enableTeleport: 0
+  _teleportThreshold: 1
+  <PrefabId>k__BackingField: 65535
+  <SpawnableCollectionId>k__BackingField: 0
+  <AssetPathHash>k__BackingField: 5809542930376490659
+  <SceneId>k__BackingField: 0
+  SerializedTransformProperties:
+    Position: {x: 0, y: 0, z: 0}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+    Scale: {x: 0, y: 0, z: 0}
+    IsValid: 0
 --- !u!1001 &1558564402756801498
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Multiplayer/EnemyBaseMultiplayer.prefab
+++ b/Assets/Prefabs/Multiplayer/EnemyBaseMultiplayer.prefab
@@ -159,6 +159,7 @@ MonoBehaviour:
   baseDamage: 10
   attackCooldown: 2
   attackDurationAdjustment: -0.2
+  movementSpeed: 2
   drop: {fileID: 4351147015997587858, guid: ad41b46d90d46a84db8d7e734165c44d, type: 3}
 --- !u!195 &7546450163983781143
 NavMeshAgent:

--- a/Assets/Prefabs/WoodLog.prefab
+++ b/Assets/Prefabs/WoodLog.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 259951086460573985}
   - component: {fileID: 3603112812403096430}
   - component: {fileID: 1978401069597958036}
+  - component: {fileID: 8412306589285422451}
   m_Layer: 0
   m_Name: WoodLog
   m_TagString: Untagged
@@ -96,6 +97,58 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   item: {fileID: 11400000, guid: 6cd66256642c52241bcabfa1ff5b7884, type: 2}
+--- !u!114 &8412306589285422451
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3421859495812559835}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26b716c41e9b56b4baafaf13a523ba2e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <IsNested>k__BackingField: 0
+  WasActiveDuringEdit: 0
+  WasActiveDuringEdit_Set1: 1
+  <ComponentIndex>k__BackingField: 0
+  <PredictedSpawn>k__BackingField: {fileID: 0}
+  <PredictedOwner>k__BackingField: {fileID: 0}
+  NetworkBehaviours: []
+  InitializedParentNetworkBehaviour: {fileID: 0}
+  InitializedNestedNetworkObjects: []
+  RuntimeParentNetworkBehaviour: {fileID: 0}
+  RuntimeChildNetworkBehaviours: []
+  _isNetworked: 1
+  _isSpawnable: 1
+  _isGlobal: 0
+  _initializeOrder: 0
+  _preventDespawnOnDisconnect: 0
+  _defaultDespawnType: 0
+  NetworkObserver: {fileID: 0}
+  _enablePrediction: 0
+  _predictionType: 0
+  _graphicalObject: {fileID: 0}
+  _detachGraphicalObject: 0
+  _enableStateForwarding: 1
+  _networkTransform: {fileID: 0}
+  _ownerInterpolation: 1
+  _ownerSmoothedProperties: 255
+  _adaptiveInterpolation: 3
+  _spectatorSmoothedProperties: 255
+  _spectatorInterpolation: 2
+  _enableTeleport: 0
+  _teleportThreshold: 1
+  <PrefabId>k__BackingField: 65535
+  <SpawnableCollectionId>k__BackingField: 0
+  <AssetPathHash>k__BackingField: 16153189904123671423
+  <SceneId>k__BackingField: 0
+  SerializedTransformProperties:
+    Position: {x: 0, y: 0, z: 0}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+    Scale: {x: 0, y: 0, z: 0}
+    IsValid: 0
 --- !u!1 &6466788560391326779
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Inventory/LootableObject.cs
+++ b/Assets/Scripts/Inventory/LootableObject.cs
@@ -1,9 +1,10 @@
 using Assets.Scripts.Interfaces;
+using FishNet.Object;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class LootableObject : MonoBehaviour, IDamageable, IDeath
+public class LootableObject : NetworkBehaviour, IDamageable, IDeath
 {
     private float health = 30f;
     [SerializeField]
@@ -20,9 +21,14 @@ public class LootableObject : MonoBehaviour, IDamageable, IDeath
 
     public void OnDeath(string killedById)
     {
-
-        Instantiate(item,transform.position,transform.rotation);
+        SpawnDrop();
         Destroy(gameObject);
+    }
+
+    public void SpawnDrop()
+    {
+        var loot = Instantiate(item, transform.position, transform.rotation);
+        ServerManager.Spawn(loot);
     }
 
     public string GetTag() { return gameObject.tag; }


### PR DESCRIPTION
- Introduced a new MonoBehaviour entry in `DefaultPrefabObjects.asset`.
- Added a new component to `Bones.prefab`.
- Updated `EnemyBaseMultiplayer.prefab` with `movementSpeed` and a new drop item.
- Added a new component to `WoodLog.prefab`.
- Changed `LootableObject` to inherit from `NetworkBehaviour` for network compatibility.
- Refactored `OnDeath` method to use `SpawnDrop()` for loot instantiation.
- Added `GetTag()` method to return the object's tag.